### PR TITLE
Add support to user:pass when using http, https maybe even ftp for the script source

### DIFF
--- a/agent/org.linkedin.glu.agent-impl/src/main/groovy/org/linkedin/glu/agent/impl/capabilities/ShellImpl.groovy
+++ b/agent/org.linkedin.glu.agent-impl/src/main/groovy/org/linkedin/glu/agent/impl/capabilities/ShellImpl.groovy
@@ -320,7 +320,21 @@ def class ShellImpl implements Shell
       tempFile = tempFile.createRelative(filename)
     }
 
-    ant { ant -> ant.get(src: uri, dest: tempFile.file) }
+    // See http://download.oracle.com/javase/1.4.2/docs/api/java/net/URI.html#getUserInfo()
+    // Extract the user:pass if it exists
+    String username = null
+    String password = null
+    def userInfo = uri.userInfo
+    if(userInfo)
+    {
+      userInfo = userInfo.split(":")
+      if(userInfo.length == 2)
+      {
+        username = userInfo[0]
+        password = userInfo[1]
+      }
+    }
+    ant { ant -> ant.get(src: uri, dest: tempFile.file, username: username, password: password) }
 
     return tempFile
   }


### PR DESCRIPTION
Was mentioned here: 
http://glu.977617.n3.nabble.com/Using-user-pass-in-http-urls-for-quot-script-quot-td2131667.html

OK, I tested, looks working for me.
If the user:pass is missing this also works, for example I tried a few things:

```
"script": "file:/script.groovy"
```

or 

```
"script": "http://www.google.com/"
```

This worked too (of course groovy bailed on compilation but that's fine)
