### PR TITLE
Add missing -s $GLU_ZK_CONNECT_STRING to zk.sh in setup-agent.sh

### DIFF
--- a/packaging/org.linkedin.glu.packaging-setup/src/cmdline/resources/bin/setup-agent.sh
+++ b/packaging/org.linkedin.glu.packaging-setup/src/cmdline/resources/bin/setup-agent.sh
@@ -110,7 +110,7 @@ if [ ! -z "$VERBOSE" ]; then
   echo GLU_ZK_CLI=$GLU_ZK_CLI
 fi
 
-CMD="$GLU_ZK_CLI put -f $GLU_AGENT_FABRIC $GLU_ZK_ROOT/agents/names/$GLU_AGENT_NAME/fabric"
+CMD="$GLU_ZK_CLI -s $GLU_ZK_CONNECT_STRING put -f $GLU_AGENT_FABRIC $GLU_ZK_ROOT/agents/names/$GLU_AGENT_NAME/fabric"
 if [ ! -z "$VERBOSE" ]; then
   echo $CMD
 fi


### PR DESCRIPTION
I think that in setup-agent.sh is missing a -s $GLU_ZK_CONNECT_STRING when calling to zk.sh
