### PR TITLE
Sometimes ste.message is null. It is null when the exception is java.util

### DIFF
--- a/console/org.linkedin.glu.console-webapp/grails-app/views/agents/view.gsp
+++ b/console/org.linkedin.glu.console-webapp/grails-app/views/agents/view.gsp
@@ -109,7 +109,7 @@
             <dd class="errorStackTrace">
               <dl id="stackTraceBody_${mountPoint.mountPoint}">
                 <g:each in="${specialEntry.value}" var="ste">
-                  <dt class="stackTraceHeader">* ${ste.name.encodeAsHTML()}: "${ste.message.encodeAsHTML()}"</dt>
+                  <dt class="stackTraceHeader">* ${ste.name.encodeAsHTML()}: "${ste.message?.encodeAsHTML()}"</dt>
                 </g:each>
               </dl>
             </dd>


### PR DESCRIPTION
Fix error (NPE) on an agent page http://glu.outbrain.com:8080/console/agents/view/agent01.glu.com

Sometimes ste.message is null. It is null when the exception is java.util.concurrent.TimeoutException, it's message is simply null so encodeAsHTML fails. 
