### PR TITLE
Add some spacing around the pagination items.  

### DIFF
--- a/console/org.linkedin.glu.console-webapp/grails-app/views/plan/archived.gsp
+++ b/console/org.linkedin.glu.console-webapp/grails-app/views/plan/archived.gsp
@@ -27,6 +27,10 @@
   table#deployment td {
     padding: 0.5em;
   }
+  .step {
+    padding: .2em;
+    margin: .4em;
+  }
   </style>
 </head>
 <body>


### PR DESCRIPTION
I'm sorry, but I didn't find the <g:paginate> component, so I fixed it right on the page's CSS. A getter fix is probably to fix the root at the component definition, or alternatively in an external CSS
