### PR TITLE
#92: Fix unit tests running on Linux

### DIFF
--- a/agent/org.linkedin.glu.agent-impl/src/test/groovy/test/agent/impl/TestCapabilities.groovy
+++ b/agent/org.linkedin.glu.agent-impl/src/test/groovy/test/agent/impl/TestCapabilities.groovy
@@ -139,7 +139,7 @@ class TestCapabilities extends GroovyTestCase
       // now we try with a file directly:
       shellScript = shellScript.file.canonicalPath
       assertEquals("Hello a b c", shell.exec("${shellScript} a b c"))
-      assertEquals("       1       1       6", shell.exec("${shellScript} | wc"))
+      assertEquals("       1       1       6".trim(), shell.exec("${shellScript} | wc").trim())
 
       // we make the shell script non executable
       fs.chmod(shellScript, '-x')
@@ -333,8 +333,8 @@ line 3 abcdef
         assertEquals(originalSizes[path - '.gz'] - size, res[shell.toResource(path)])
       }
 
-      assertTrue(GroovyCollectionsUtils.compareIgnoreType(expectedResult, res.keySet().path))
-      assertTrue(GroovyCollectionsUtils.compareIgnoreType(expectedResult, leavesPaths(root)))
+      assertEquals(expectedResult, res.keySet().path.sort())
+      assertEquals(expectedResult, leavesPaths(root).toArray().sort())
     }
   }
 
@@ -355,8 +355,9 @@ line 3 abcdef
       fs.eachChildRecurse(root) { r ->
         files << r.path
       }
+      files.sort()
 
-      def expectedFiles = ['/root/dir1', '/root/e.txt', '/root/dir1/a.txt', '/root/dir1/b.txt', '/root/dir1/dir2', '/root/dir1/dir2/c.txt', '/root/dir1/dir2/d.txt']
+      def expectedFiles = ['/root/dir1', '/root/e.txt', '/root/dir1/a.txt', '/root/dir1/b.txt', '/root/dir1/dir2', '/root/dir1/dir2/c.txt', '/root/dir1/dir2/d.txt'].sort()
       assertEquals(expectedFiles, files)
 
       // find only dirs under root


### PR DESCRIPTION
The test target runs to completion on the following system.

```
$ lsb_release -a
Distributor ID: CentOS
Description:    CentOS release 5.7 (Final)
Release:        5.7
Codename:       Final

$ java -version
java version "1.6.0_05"
Java(TM) SE Runtime Environment (build 1.6.0_05-b13)
Java HotSpot(TM) Server VM (build 10.0-b19, mixed mode)

$ gradle -v        
Gradle build time: Sunday, 23 January 2011 01:34:21 PM EST
Groovy: 1.7.6
Ant: Apache Ant version 1.8.1 compiled on April 30 2010
Ivy: 2.2.0
JVM: 1.6.0_05 (Sun Microsystems Inc. 10.0-b19)
OS: Linux 2.6.18-274.7.1.el5PAE i386

$ grails
Welcome to Grails 1.3.5 - http://grails.org/
Licensed under Apache Standard License 2.0
Grails home is set to: /opt/apps/grails-1.3.5
```
