### PR TITLE
Add support for nesting /console/ in a sub url in console-cli.py.

### DIFF
--- a/console/org.linkedin.glu.console-cli/src/cmdline/resources/lib/python/gluconsole/rest.py
+++ b/console/org.linkedin.glu.console-cli/src/cmdline/resources/lib/python/gluconsole/rest.py
@@ -46,7 +46,7 @@ class Client:
   def __init__(self, fabric="dev", url="http://localhost:8080", username="glua", password="password"
                , version="v1"):
     self.uriBase = url
-    self.uriPath = "/console/rest/" + version + "/" + fabric
+    self.uriPath = "console/rest/%s/%s" % (version, fabric)
     self.auth = restkit.BasicAuth(username, password)
     self._action_successful = None
 
@@ -152,7 +152,7 @@ class Client:
       self._action_successful = True
       return "GLU Console message: %s" % createdPlan.status.split(' ', 1)[-1]
 
-    url2UriPat = "https?://[-\.\w:]*" + self.uriPath + "/"
+    url2UriPat = r"https?://[-.:\w]+/(?:.*?/)?%s/" % self.uriPath
 
     # unique identifier for the plan just created
     planUrl = createdPlan['location']


### PR DESCRIPTION
This will allow console urls such as http://glu:8080/glu/console, the -c argument for console-cli.py would then be "http://glu:8080/glu".
