### PR TITLE
handle unexpected output while setting JAVA_TOOL_OPTIONS enviroment variable

### DIFF
--- a/agent/org.linkedin.glu.agent-cli/src/cmdline/resources/bin/agent-cli.sh
+++ b/agent/org.linkedin.glu.agent-cli/src/cmdline/resources/bin/agent-cli.sh
@@ -51,7 +51,7 @@ if [ -z "$JAVA_CMD" ]; then
   fi
 fi
 
-JAVA_VER=$("$JAVA_CMD" -version 2>&1 | sed 's/java version "\(.*\)\.\(.*\)\..*"/\1\2/; 1q')
+JAVA_VER=$("$JAVA_CMD" -version 2>&1 | grep 'java version' | sed 's/java version "\(.*\)\.\(.*\)\..*"/\1\2/; 1q')
 if [ "$JAVA_VER" -lt 17 ]; then
 	echo "### ERROR START ###########"
 	echo "### Java @ $JAVA_CMD too old (required java 1.7)"

--- a/agent/org.linkedin.glu.agent-server-upgrade/src/cmdline/resources/conf/master_conf.sh
+++ b/agent/org.linkedin.glu.agent-server-upgrade/src/cmdline/resources/conf/master_conf.sh
@@ -25,7 +25,7 @@ if [ -z "$JAVA_CMD" ]; then
   fi
 fi
 
-JAVA_VER=$("$JAVA_CMD" -version 2>&1 | sed 's/java version "\(.*\)\.\(.*\)\..*"/\1\2/; 1q')
+JAVA_VER=$("$JAVA_CMD" -version 2>&1 | grep 'java version' | sed 's/java version "\(.*\)\.\(.*\)\..*"/\1\2/; 1q')
 if [ "$JAVA_VER" -lt 17 ]; then
 	echo "### ERROR START ###########"
 	echo "### Java @ $JAVA_CMD too old (required java 1.7)"
@@ -38,10 +38,10 @@ if [ -z "$JAVA_CMD_TYPE" ]; then
   FULLVERSION=$( $JAVA_CMD -fullversion 2>&1 )
   if [ -z "$(echo $FULLVERSION | grep IBM)" ]; then
     JAVA_CMD_TYPE=oracle
-  else    
+  else
     JAVA_CMD_TYPE=ibm
   fi
-fi 
+fi
 
 if [ -z "$GLU_CONFIG_PREFIX" ]; then
   GLU_CONFIG_PREFIX="glu"
@@ -157,7 +157,7 @@ if [ -z "$JVM_GC_LOG" ]; then
     'oracle' ) JVM_GC_LOG="-XX:+PrintGCDateStamps -Xloggc:$GC_LOG"
     	       ;;
   esac
-  
+
 fi
 
 # Log4J configuration

--- a/console/org.linkedin.glu.console-server/src/cmdline/resources/conf/master_conf.sh
+++ b/console/org.linkedin.glu.console-server/src/cmdline/resources/conf/master_conf.sh
@@ -24,7 +24,7 @@ if [ -z "$JAVA_CMD" ]; then
   fi
 fi
 
-JAVA_VER=$("$JAVA_CMD" -version 2>&1 | sed 's/java version "\(.*\)\.\(.*\)\..*"/\1\2/; 1q')
+JAVA_VER=$("$JAVA_CMD" -version 2>&1 | grep 'java version' | sed 's/java version "\(.*\)\.\(.*\)\..*"/\1\2/; 1q')
 if [ "$JAVA_VER" -lt 17 ]; then
 	echo "### ERROR START ###########"
 	echo "### Java @ $JAVA_CMD too old (required java 1.7)"

--- a/packaging/org.linkedin.glu.packaging-all/src/cmdline/resources/bin/setup-pre-510.sh
+++ b/packaging/org.linkedin.glu.packaging-all/src/cmdline/resources/bin/setup-pre-510.sh
@@ -135,7 +135,7 @@ if [ -z "$JAVA_CMD" ]; then
   fi
 fi
 
-JAVA_VER=$("$JAVA_CMD" -version 2>&1 | sed 's/java version "\(.*\)\.\(.*\)\..*"/\1\2/; 1q')
+JAVA_VER=$("$JAVA_CMD" -version 2>&1 | grep 'java version' | sed 's/java version "\(.*\)\.\(.*\)\..*"/\1\2/; 1q')
 if [ "$JAVA_VER" -lt 17 ]; then
 	echo "### ERROR START ###########"
 	echo "### Java @ $JAVA_CMD too old (required java 1.7)"

--- a/packaging/org.linkedin.glu.packaging-all/src/cmdline/resources/bin/tutorial.sh
+++ b/packaging/org.linkedin.glu.packaging-all/src/cmdline/resources/bin/tutorial.sh
@@ -57,7 +57,7 @@ init()
   GLU_TUTORIAL_CONSOLE_LINK=$GLU_TUTORIAL_DIR/console-server
   GLU_TUTORIAL_CONSOLE_CLI_LINK=$GLU_TUTORIAL_DIR/console-cli
   GLU_TUTORIAL_ZOOKEEPER_LINK=$GLU_TUTORIAL_DIR/zookeeper-server
-  
+
 }
 
 usage()
@@ -174,7 +174,7 @@ if [ -z "$JAVA_CMD" ]; then
   fi
 fi
 
-JAVA_VER=$("$JAVA_CMD" -version 2>&1 | sed 's/java version "\(.*\)\.\(.*\)\..*"/\1\2/; 1q')
+JAVA_VER=$("$JAVA_CMD" -version 2>&1 | grep 'java version' | sed 's/java version "\(.*\)\.\(.*\)\..*"/\1\2/; 1q')
 if [ "$JAVA_VER" -lt 17 ]; then
 	echo "### ERROR START ###########"
 	echo "### Java @ $JAVA_CMD too old (required java 1.7)"

--- a/packaging/org.linkedin.glu.packaging-setup/src/cmdline/resources/bin/setup.sh
+++ b/packaging/org.linkedin.glu.packaging-setup/src/cmdline/resources/bin/setup.sh
@@ -55,7 +55,7 @@ if [ -z "$JAVA_CMD" ]; then
   fi
 fi
 
-JAVA_VER=$("$JAVA_CMD" -version 2>&1 | sed 's/java version "\(.*\)\.\(.*\)\..*"/\1\2/; 1q')
+JAVA_VER=$("$JAVA_CMD" -version 2>&1 | grep 'java version' | sed 's/java version "\(.*\)\.\(.*\)\..*"/\1\2/; 1q')
 if [ "$JAVA_VER" -lt 17 ]; then
 	echo "### ERROR START ###########"
 	echo "### Java @ $JAVA_CMD too old (required java 1.7)"


### PR DESCRIPTION
I set the variable of JAVA_TOOL_OPTIONS on OS X, so the bash failed with the unexpected output: 
    Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8
