### PR TITLE
agentctl.sh: Sanity check PID_FILE and remove at stop

### DIFF
--- a/agent/org.linkedin.glu.agent-server-upgrade/src/cmdline/resources/bin/agentctl.sh
+++ b/agent/org.linkedin.glu.agent-server-upgrade/src/cmdline/resources/bin/agentctl.sh
@@ -133,6 +133,7 @@ stop()
   if [ $(pid_status) -ne 0 ]
   then
     status
+    rm -f $PID_FILE
     exit 0
   fi
 
@@ -140,6 +141,7 @@ stop()
   kill $OPT_FORCEKILL `cat $PID_FILE`
 
   echo "Stopping $APP_NAME - PID [`cat $PID_FILE`]"
+  rm -f $PID_FILE
 }
 
 ###############################################################################
@@ -202,14 +204,19 @@ get_pid()
     PID=`cat $PID_FILE`
     PS_STAT=`ps -p $PID -o'user,pid=' | tail -1 | awk '{print $2}'`
 
-    case "$PS_STAT" in
-      $PID  ) echo $PID
-              ;;
-      *     ) echo 0
-              ;;
-    esac
+    if [[ "$PS_STAT" -eq "$PID" ]]; then
+      CMD=$(ps -p $PID -o 'comm=')
+      if [[ "$CMD" == "$(basename "$JAVA_CMD")" ]]; then
+        echo $PID
+      else
+        echo 0
+      fi
+    else
+      echo 0
+    fi
+
   fi
-  
+
   return 0
 }
 


### PR DESCRIPTION
PID files are inherently problematic because PIDs are reused.  This
means that at start up if we find a PID file and there is a running
process with that PID we do nothing.  Unfortunately it is possible that
our process long since died, PIDs have wrapped and are now getting
reused and the process we found is an unrelated process.  The problem is
even more likely at system start time if we find a PID file from the
previous system boot.  In this case the system is starting up and
spawning many new processes and it is likely that the low numbered PID
we received on the previous boot will be near other processes starting
in parallel.

To help solve this problem we can remove stale PID files when we shut
down cleanly.  Additionally we can perform a basic sanity check if we
find a PID file and find the PID running to compare that they at least
have the command we expect.  This commit performs both of these actions.

Additionally PID files are typically written to /var/run or /run
which get cleared on reboots.  I am not making that change since I do
not know if there would be any ramifications to moving the location of
the PID file.

Signed-off-by: Shawn Bohrer <sbohrer@rgmadvisors.com>